### PR TITLE
refactor: establish frontend information hierarchy

### DIFF
--- a/product-drill-app/src/app/globals.css
+++ b/product-drill-app/src/app/globals.css
@@ -1,40 +1,151 @@
-﻿:root {
-  --bg: #f4f2ec;
-  --surface: #fffefb;
-  --surface-strong: #ece9e1;
-  --ink: #121826;
-  --ink-soft: #4f5868;
-  --ink-faint: #7d8491;
-  --line: #dedbd2;
-  --navy: #111827;
-  --sage: #dce8df;
-  --sage-strong: #2e6a4f;
-  --coral: #e66b5b;
-  --coral-soft: #f8ded8;
+/* ============================================================================
+   Product Drill — "The Calibration Ledger" design system
+   ----------------------------------------------------------------------------
+   The product proves judgment through traceable evidence, so the type system
+   encodes that epistemology as three unmistakable tiers:
+
+     标题  CLAIM      → serif display  · near-black  · 600–700  (the judgment)
+     说明  EVIDENCE   → sans body      · mid ink     · 400      (the reasoning)
+     辅助  PROVENANCE → mono data      · muted ink   · 500 tab  (the record)
+
+   Size, weight, family and color all move together per tier, so a title can
+   never be mistaken for a caption.
+   ========================================================================== */
+
+:root {
+  /* ── Ink ramp: three clear tiers of emphasis ─────────────────────────── */
+  --ink: #151a22;        /* claims — deepest, highest contrast            */
+  --ink-2: #414a58;      /* evidence — clearly lighter, still readable     */
+  --ink-3: #7b8290;      /* provenance — clearly muted                     */
+  --ink-muted: var(--ink-3); /* legacy alias kept for runtime notices       */
+
+  /* ── Paper & structure ───────────────────────────────────────────────── */
+  --paper: #f5f3ee;
+  --bg: var(--paper);
+  --surface: #fdfcf9;
+  --surface-strong: #ebeae2;
+  --line: #e0ddd2;
   --white: #ffffff;
-  --shadow: 0 16px 38px rgba(20, 25, 36, 0.06);
+
+  /* ── Dark surfaces (claims sit on these) ─────────────────────────────── */
+  --navy: #141a26;
+  --on-dark-title: #f5f2ea;
+  --on-dark-body: #c3cad5;
+  --on-dark-aux: #8d96a6;
+
+  /* ── Epistemic accents: sage = independent evidence, coral = assisted/risk ── */
+  --sage: #dce8df;
+  --sage-strong: #2e6a4f;   /* independent evidence and coverage            */
+  --pine-light: #a8d2b8;    /* kicker on dark                               */
+  --coral: #d95c4b;         /* assisted evidence, counterfactual, risk      */
+  --coral-strong: #b0432f;
+  --coral-soft: #f8e0da;
+  --amber: #976a1e;         /* in-progress, medium confidence               */
+  --amber-soft: #f3e7cb;
+  --indigo-soft: #e6e9f6;   /* transfer evidence                            */
+  --indigo: #3b4aa8;
+
+  /* ── Type families (one per tier). Local stacks — no external webfont, so
+        the hierarchy holds offline and behind the GFW. A premium face is used
+        when installed, otherwise the platform's native serif / sans / mono. ── */
+  --font-display: "Noto Serif SC", "Source Han Serif SC", "Songti SC", "STSongti", "STSong", "SimSun", "NSimSun", serif;
+  --font-body: "Inter", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC", system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-mono: "IBM Plex Mono", "JetBrains Mono", "Cascadia Code", "SF Mono", ui-monospace, "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace;
+
+  /* ── Type scale: deliberate jumps between tiers ──────────────────────── */
+  --fs-display: clamp(2.05rem, 1.45rem + 2.5vw, 2.85rem);  /* page claim    */
+  --fs-hero: clamp(1.95rem, 1.35rem + 2.6vw, 2.95rem);     /* hero claim    */
+  --fs-title-lg: 1.625rem;   /* 26px — major section title                 */
+  --fs-title: 1.25rem;       /* 20px — section / card title                */
+  --fs-title-sm: 1.0625rem;  /* 17px — item title                          */
+  --fs-lede: 1.0625rem;      /* 17px — one-line intro under a title        */
+  --fs-body: 0.9375rem;      /* 15px — standard evidence / description     */
+  --fs-body-sm: 0.875rem;    /* 14px — dense evidence                      */
+  --fs-aux: 0.8125rem;       /* 13px — provenance / data                   */
+  --fs-aux-sm: 0.75rem;      /* 12px — smallest provenance                 */
+  --fs-kicker: 0.6875rem;    /* 11px — eyebrow label                       */
+
+  /* ── Shape & shadow ──────────────────────────────────────────────────── */
   --radius: 12px;
   --radius-sm: 8px;
+  --shadow: 0 16px 38px rgba(20, 25, 36, 0.06);
 }
 
 * { box-sizing: border-box; }
 html { background: var(--bg); }
 body {
   margin: 0;
-  color: var(--ink);
+  color: var(--ink-2);
   background: var(--bg);
-  font-family: Inter, "Noto Sans SC", "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
+  font-family: var(--font-body);
+  font-size: var(--fs-body);
+  line-height: 1.6;
   -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
-button, input, textarea, select { font: inherit; }
+button, input, textarea, select { font: inherit; font-family: var(--font-body); }
 button { cursor: pointer; }
 button:disabled { cursor: not-allowed; opacity: 0.46; }
 
-h1, h2, h3, p { margin-top: 0; }
-h1, h2, h3 { letter-spacing: -0.035em; }
-p { color: var(--ink-soft); line-height: 1.65; }
+/* ── Tier 1: CLAIMS — serif, near-black, present ───────────────────────── */
+h1, h2, h3, h4, p { margin-top: 0; }
+h1, h2, h3, h4 {
+  font-family: var(--font-display);
+  color: var(--ink);
+  font-weight: 600;
+  line-height: 1.22;
+  letter-spacing: -0.01em;
+  text-wrap: balance;
+}
+/* ── Tier 2: EVIDENCE — sans, mid-ink, calm ────────────────────────────── */
+p { color: var(--ink-2); line-height: 1.66; }
 
-.app-shell { min-height: 100vh; display: grid; grid-template-columns: 248px minmax(0, 1fr); }
+/* ── Tier 3: PROVENANCE — mono, muted, letterspaced, tabular ───────────── */
+.aux,
+.detail-label,
+.meta-line,
+.quiet,
+.skill-index,
+.scenario-topline,
+.ev-card-meta,
+.jp-updated,
+.wb-message-role,
+.coverage-number span,
+.summary-stats span,
+.review-metrics span,
+.ability-counts,
+.sidebar-footer > span,
+.user span,
+.hero-proof span,
+.message > span,
+.scenario-skill span,
+.review-list button i,
+.login-proof span,
+.skill-label,
+.provenance {
+  font-family: var(--font-mono);
+  color: var(--ink-3);
+  font-size: var(--fs-aux-sm);
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Eyebrow / kicker — a section label, not data: sans caps, tinted */
+.section-kicker {
+  display: inline-block;
+  margin-bottom: 12px;
+  color: var(--sage-strong);
+  font-family: var(--font-body);
+  font-size: var(--fs-kicker);
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+.section-kicker.light { color: var(--pine-light); }
+
+/* ══════════════════════════ APP SHELL ══════════════════════════════════ */
+.app-shell { min-height: 100vh; display: grid; grid-template-columns: 256px minmax(0, 1fr); }
 .sidebar {
   position: sticky;
   top: 0;
@@ -51,15 +162,16 @@ p { color: var(--ink-soft); line-height: 1.65; }
   height: 38px;
   display: grid;
   place-items: center;
-  color: var(--white);
+  color: var(--on-dark-title);
   background: var(--navy);
   border-radius: 9px;
+  font-family: var(--font-mono);
   font-size: 12px;
-  font-weight: 800;
+  font-weight: 600;
   letter-spacing: 0.08em;
 }
-.brand strong { display: block; font-size: 15px; }
-.brand span { display: block; margin-top: 3px; color: var(--ink-faint); font-size: 12px; }
+.brand strong { display: block; font-family: var(--font-display); font-size: 16px; font-weight: 600; color: var(--ink); }
+.brand span { display: block; margin-top: 3px; color: var(--ink-3); font-size: var(--fs-aux-sm); }
 .sidebar nav { display: grid; gap: 6px; margin-top: 24px; }
 .sidebar nav button {
   width: 100%;
@@ -71,152 +183,160 @@ p { color: var(--ink-soft); line-height: 1.65; }
   text-align: left;
   border: 1px solid transparent;
   border-radius: 9px;
-  color: var(--ink-soft);
+  color: var(--ink-2);
   background: transparent;
 }
-.sidebar nav button > span { padding-top: 2px; color: #9a9da4; font-size: 10px; font-weight: 700; }
-.sidebar nav button strong { display: block; color: inherit; font-size: 14px; font-weight: 650; }
-.sidebar nav button small { display: block; margin-top: 4px; color: var(--ink-faint); font-size: 10px; line-height: 1.4; }
+.sidebar nav button > span { padding-top: 2px; color: var(--ink-3); font-family: var(--font-mono); font-size: 10px; font-weight: 600; }
+.sidebar nav button strong { display: block; color: inherit; font-size: 14px; font-weight: 600; }
+.sidebar nav button small { display: block; margin-top: 4px; color: var(--ink-3); font-size: var(--fs-aux-sm); line-height: 1.45; }
 .sidebar nav button:hover { background: rgba(255, 255, 255, 0.7); border-color: var(--line); }
-.sidebar nav button.active { color: var(--white); background: var(--navy); box-shadow: 0 10px 24px rgba(17, 24, 39, 0.12); }
-.sidebar nav button.active > span, .sidebar nav button.active small { color: #aeb5c2; }
+.sidebar nav button.active { color: var(--on-dark-title); background: var(--navy); box-shadow: 0 10px 24px rgba(17, 24, 39, 0.12); }
+.sidebar nav button.active strong { color: var(--on-dark-title); }
+.sidebar nav button.active > span, .sidebar nav button.active small { color: var(--on-dark-aux); }
 .sidebar-footer { margin-top: auto; padding: 16px 10px 0; border-top: 1px solid var(--line); }
-.sidebar-footer > span { color: var(--ink-faint); font-size: 11px; }
-.sidebar-footer > strong { float: right; font-size: 13px; }
+.sidebar-footer > strong { float: right; font-family: var(--font-mono); font-size: 13px; font-weight: 600; color: var(--ink-3); font-variant-numeric: tabular-nums; }
 .sidebar-footer > div { height: 5px; margin-top: 12px; overflow: hidden; background: #deddd7; border-radius: 999px; }
 .sidebar-footer i { display: block; height: 100%; background: var(--sage-strong); }
 
 .main { min-width: 0; }
 .topbar {
-  min-height: 108px;
-  padding: 28px clamp(28px, 4vw, 58px) 22px;
+  min-height: 118px;
+  padding: 30px clamp(28px, 4vw, 58px) 24px;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 24px;
   border-bottom: 1px solid var(--line);
-  background: rgba(244, 242, 236, 0.94);
+  background: rgba(245, 243, 238, 0.94);
 }
-.topbar h1 { margin-bottom: 6px; font-size: clamp(25px, 2.3vw, 36px); line-height: 1.15; }
-.topbar p { margin-bottom: 0; font-size: 13px; }
+/* Page claim — the single biggest, serif statement on the screen */
+.topbar h1 { margin-bottom: 8px; font-size: var(--fs-display); font-weight: 600; line-height: 1.16; }
+.topbar p { margin-bottom: 0; font-size: var(--fs-lede); color: var(--ink-2); }
 .user { padding: 8px 0 8px 18px; display: flex; flex-direction: column; text-align: right; border-left: 1px solid var(--line); }
-.user span { color: var(--ink-faint); font-size: 10px; }
-.user strong { margin-top: 2px; font-size: 13px; }
-.content { padding: 30px clamp(28px, 4vw, 58px) 64px; }
+.user strong { margin-top: 3px; font-size: 14px; font-weight: 600; color: var(--ink); }
+.content { padding: 32px clamp(28px, 4vw, 58px) 72px; }
 
+/* ══════════════════════════ PRIMITIVES ═════════════════════════════════ */
 .surface, .surface-dark { border-radius: var(--radius); }
 .surface { border: 1px solid var(--line); background: var(--surface); box-shadow: var(--shadow); }
-.surface-dark { color: var(--white); background: var(--navy); box-shadow: 0 20px 50px rgba(17, 24, 39, 0.14); }
-.surface-dark p { color: #c6cbd4; }
-.section-kicker { display: inline-block; margin-bottom: 10px; color: var(--sage-strong); font-size: 10px; font-weight: 800; letter-spacing: 0.12em; text-transform: uppercase; }
-.section-kicker.light { color: #a8d2b8; }
+.surface-dark { color: var(--on-dark-body); background: var(--navy); box-shadow: 0 20px 50px rgba(17, 24, 39, 0.14); }
+.surface-dark h1, .surface-dark h2, .surface-dark h3 { color: var(--on-dark-title); }
+.surface-dark p { color: var(--on-dark-body); }
+
 .section-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px; }
-.section-heading h2 { margin-bottom: 0; font-size: 22px; line-height: 1.25; }
-.section-heading.compact h2 { font-size: 30px; }
-.quiet { color: var(--ink-faint); font-size: 12px; }
+.section-heading h2 { margin-bottom: 0; font-size: var(--fs-title-lg); line-height: 1.28; }
+.section-heading.compact h2 { font-size: var(--fs-display); }
+.quiet { font-size: var(--fs-aux); }
+
 .status-tag, .mastery {
   display: inline-flex;
   align-items: center;
-  min-height: 27px;
-  padding: 4px 9px;
-  color: var(--ink-soft);
+  min-height: 28px;
+  padding: 4px 11px;
+  color: var(--ink-2);
   border: 1px solid var(--line);
   border-radius: 999px;
   background: #f5f3ee;
-  font-size: 10px;
+  font-family: var(--font-mono);
+  font-size: var(--fs-aux-sm);
+  font-weight: 500;
   white-space: nowrap;
 }
 .mastery-可独立完成, .mastery-表现稳定 { color: #24583f; border-color: #bdd5c5; background: #e6f0e9; }
-.mastery-在提示下完成 { color: #79572a; border-color: #e2cfad; background: #f7eedc; }
+.mastery-在提示下完成 { color: var(--amber); border-color: #e2cfad; background: var(--amber-soft); }
 
 .button {
-  min-height: 42px;
-  padding: 10px 16px;
+  min-height: 44px;
+  padding: 11px 18px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 10px;
   border: 1px solid transparent;
   border-radius: 8px;
-  font-weight: 700;
+  font-family: var(--font-body);
+  font-size: var(--fs-body-sm);
+  font-weight: 600;
   transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
 }
 .button:hover:not(:disabled) { transform: translateY(-1px); }
-.button-primary { color: var(--white); background: var(--navy); box-shadow: 0 8px 18px rgba(17, 24, 39, 0.12); }
+.button-primary { color: var(--on-dark-title); background: var(--navy); box-shadow: 0 8px 18px rgba(17, 24, 39, 0.12); }
 .button-secondary { color: var(--ink); border-color: var(--line); background: var(--surface); }
 .button-light { color: var(--navy); background: var(--white); }
-.button-coral { color: #812f25; border-color: #efaaa0; background: var(--coral-soft); }
-.text-button, .back-button { padding: 0; color: var(--ink); border: 0; background: transparent; font-weight: 750; }
+.button-coral { color: var(--coral-strong); border-color: #efaaa0; background: var(--coral-soft); }
+.text-button, .back-button { padding: 0; color: var(--ink); border: 0; background: transparent; font-size: var(--fs-body-sm); font-weight: 650; }
 .text-button:hover, .back-button:hover { color: var(--sage-strong); }
 
-.today-layout { display: grid; grid-template-columns: minmax(0, 1fr) 270px; gap: 18px; }
-.hero-training { min-height: 330px; padding: clamp(28px, 4vw, 46px); display: grid; grid-template-columns: minmax(0, 1fr) 240px; gap: 36px; }
-.meta-line { display: flex; gap: 16px; color: #aeb5c2; font-size: 11px; }
-.skill-label { margin: 48px 0 10px; color: #a8d2b8 !important; font-size: 12px; font-weight: 750; }
-.hero-copy h2 { max-width: 700px; margin-bottom: 14px; font-size: clamp(30px, 3.2vw, 48px); line-height: 1.06; }
-.hero-copy > p { max-width: 700px; }
-.hero-actions { margin-top: 32px; display: flex; align-items: center; gap: 16px; }
-.hero-actions > span { color: #9da5b2; font-size: 11px; }
-.hero-proof { align-self: end; padding: 20px; border: 1px solid #30394a; border-radius: 10px; background: #171f2e; }
-.hero-proof span { color: #8f99aa; font-size: 10px; }
-.hero-proof strong { display: block; margin-top: 8px; font-size: 17px; }
-.hero-proof p { margin: 10px 0 0; font-size: 12px; }
-.weekly { min-height: 330px; padding: 28px; }
-.week-bars { height: 120px; margin: 32px 0 22px; display: flex; align-items: flex-end; gap: 8px; }
+/* ══════════════════════════ TODAY ══════════════════════════════════════ */
+.today-layout { display: grid; grid-template-columns: minmax(0, 1fr) 278px; gap: 18px; }
+.hero-training { min-height: 340px; padding: clamp(30px, 4vw, 48px); display: grid; grid-template-columns: minmax(0, 1fr) 250px; gap: 40px; }
+.meta-line { display: flex; gap: 18px; color: var(--on-dark-aux); }
+.skill-label { margin: 48px 0 12px; color: var(--pine-light) !important; font-size: var(--fs-aux); font-weight: 600; letter-spacing: 0.04em; }
+/* Hero claim — the strongest statement in the product */
+.hero-copy h2 { max-width: 720px; margin-bottom: 16px; font-size: var(--fs-hero); font-weight: 600; line-height: 1.1; letter-spacing: -0.015em; }
+.hero-copy > p { max-width: 720px; font-size: var(--fs-lede); color: var(--on-dark-body); }
+.hero-actions { margin-top: 34px; display: flex; align-items: center; flex-wrap: wrap; gap: 16px; }
+.hero-actions > span { color: var(--on-dark-aux); font-family: var(--font-mono); font-size: var(--fs-aux-sm); }
+.hero-proof { align-self: end; padding: 22px; border: 1px solid #30394a; border-radius: 10px; background: #171f2e; }
+.hero-proof span { color: var(--on-dark-aux); }
+.hero-proof strong { display: block; margin-top: 10px; font-family: var(--font-display); font-size: var(--fs-title); font-weight: 600; color: var(--on-dark-title); }
+.hero-proof p { margin: 12px 0 0; font-size: var(--fs-body-sm); color: var(--on-dark-body); }
+.weekly { min-height: 340px; padding: 28px; }
+.weekly .section-heading h2 { font-family: var(--font-mono); font-weight: 600; font-variant-numeric: tabular-nums; }
+.week-bars { height: 120px; margin: 34px 0 24px; display: flex; align-items: flex-end; gap: 8px; }
 .week-bars span { flex: 1; height: 24%; background: #e4e1da; border-radius: 4px 4px 0 0; }
 .week-bars span:nth-child(2) { height: 42%; }
 .week-bars span:nth-child(3) { height: 60%; }
 .week-bars span:nth-child(4) { height: 78%; }
 .week-bars span:nth-child(5) { height: 100%; }
 .week-bars span.done { background: var(--sage-strong); }
-.weekly > p { font-size: 12px; }
-.focus-card, .map-preview { grid-column: 1 / -1; padding: 28px; }
-.focus-grid { margin-top: 26px; display: grid; grid-template-columns: 1fr 1fr auto; align-items: end; gap: 28px; }
-.detail-label { color: var(--ink-faint); font-size: 10px; font-weight: 750; letter-spacing: 0.06em; }
-.focus-grid p { margin: 8px 0 0; font-size: 13px; }
-.skill-rows { margin-top: 24px; border-top: 1px solid var(--line); }
-.skill-row { min-height: 84px; display: grid; grid-template-columns: 42px minmax(0, 1fr) auto; align-items: center; gap: 16px; border-bottom: 1px solid var(--line); }
-.skill-index { color: #9b9a94; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; }
-.skill-row strong { font-size: 14px; }
-.skill-row p { margin: 4px 0 0; font-size: 11px; }
+.weekly > p { font-size: var(--fs-body-sm); }
+.focus-card, .map-preview { grid-column: 1 / -1; padding: 30px; }
+.focus-grid { margin-top: 28px; display: grid; grid-template-columns: 1fr 1fr auto; align-items: end; gap: 32px; }
+.focus-grid p { margin: 10px 0 0; font-size: var(--fs-body); }
+.skill-rows { margin-top: 28px; border-top: 1px solid var(--line); }
+.skill-row { min-height: 88px; display: grid; grid-template-columns: 44px minmax(0, 1fr) auto; align-items: center; gap: 18px; border-bottom: 1px solid var(--line); }
+.skill-index { font-size: var(--fs-aux); }
+.skill-row strong { font-family: var(--font-display); font-size: var(--fs-title-sm); font-weight: 600; color: var(--ink); }
+.skill-row p { margin: 5px 0 0; font-size: var(--fs-body-sm); }
 
+/* ══════════════════════════ TRAINING MAP ═══════════════════════════════ */
 .stack-lg { display: grid; gap: 20px; }
-.map-intro { padding: 32px; display: grid; grid-template-columns: 1fr 1fr; gap: 40px; }
-.map-intro h2 { margin-bottom: 0; font-size: 30px; }
-.map-intro p { margin: 0; align-self: end; }
+.map-intro { padding: 34px; display: grid; grid-template-columns: 1fr 1fr; gap: 44px; }
+.map-intro h2 { margin-bottom: 0; font-size: var(--fs-title-lg); }
+.map-intro p { margin: 0; align-self: end; font-size: var(--fs-lede); }
 .scenario-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 16px; }
-.scenario-card { min-height: 275px; padding: 24px; display: flex; flex-direction: column; }
-.scenario-topline { display: flex; justify-content: space-between; gap: 12px; color: var(--ink-faint); font-size: 10px; }
-.scenario-card h2 { margin: 42px 0 8px; font-size: 24px; }
-.scenario-card > p { font-size: 12px; }
-.scenario-skill { margin-top: auto; padding-top: 18px; display: flex; justify-content: space-between; border-top: 1px solid var(--line); }
-.scenario-skill span { color: var(--ink-faint); font-size: 10px; }
-.scenario-skill strong { font-size: 12px; }
-.scenario-card .text-button { margin-top: 18px; text-align: left; }
+.scenario-card { min-height: 280px; padding: 26px; display: flex; flex-direction: column; }
+.scenario-card h2 { margin: 44px 0 10px; font-size: var(--fs-title-lg); }
+.scenario-card > p { font-size: var(--fs-body); }
+.scenario-skill { margin-top: auto; padding-top: 20px; display: flex; justify-content: space-between; align-items: baseline; border-top: 1px solid var(--line); }
+.scenario-skill strong { font-family: var(--font-display); font-size: var(--fs-title-sm); font-weight: 600; color: var(--ink); }
+.scenario-card .text-button { margin-top: 20px; text-align: left; }
 
-.training-shell { display: grid; grid-template-columns: 250px minmax(420px, 1fr) 245px; gap: 16px; align-items: stretch; }
+/* ══════════════════════════ TRAINING WORKSPACE ═════════════════════════ */
+.training-shell { display: grid; grid-template-columns: 256px minmax(420px, 1fr) 250px; gap: 16px; align-items: stretch; }
 .briefing, .conversation, .training-progress { min-height: calc(100vh - 202px); }
-.briefing { padding: 24px; }
+.briefing { padding: 26px; }
 .back-button { margin-bottom: 40px; }
-.briefing h2 { font-size: 24px; }
-.briefing > p { font-size: 12px; }
-.briefing-list { margin: 26px 0; display: grid; gap: 12px; }
-.briefing-list > div { display: flex; align-items: flex-start; gap: 8px; color: var(--ink-soft); font-size: 11px; line-height: 1.5; }
+.briefing h2 { font-size: var(--fs-title-lg); }
+.briefing > p { font-size: var(--fs-body); }
+.briefing-list { margin: 28px 0; display: grid; gap: 14px; }
+.briefing-list > div { display: flex; align-items: flex-start; gap: 9px; color: var(--ink-2); font-size: var(--fs-body-sm); line-height: 1.55; }
 .check { flex: 0 0 auto; width: 17px; height: 17px; display: inline-grid; place-items: center; color: #b7b8b3; border: 1px solid #cfcdc6; border-radius: 50%; font-size: 9px; }
 .check.active { color: var(--white); border-color: var(--sage-strong); background: var(--sage-strong); }
 .mode-switch { padding: 4px; display: grid; grid-template-columns: repeat(3, 1fr); gap: 4px; border: 1px solid var(--line); border-radius: 8px; background: #f2f0ea; }
-.mode-switch button { padding: 8px 4px; color: var(--ink-soft); border: 0; border-radius: 5px; background: transparent; font-size: 10px; }
-.mode-switch button.active { color: var(--white); background: var(--navy); }
+.mode-switch button { padding: 8px 4px; color: var(--ink-2); border: 0; border-radius: 5px; background: transparent; font-size: var(--fs-aux-sm); font-weight: 600; }
+.mode-switch button.active { color: var(--on-dark-title); background: var(--navy); }
 .conversation { display: flex; flex-direction: column; overflow: hidden; }
-.conversation-head { padding: 22px 24px; display: flex; justify-content: space-between; border-bottom: 1px solid var(--line); }
-.conversation-head h2 { margin-bottom: 0; font-size: 19px; }
-.message-list { min-height: 300px; max-height: calc(100vh - 470px); padding: 26px; display: flex; flex-direction: column; gap: 18px; overflow-y: auto; }
+.conversation-head { padding: 24px; display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; border-bottom: 1px solid var(--line); }
+.conversation-head h2 { margin-bottom: 0; font-size: var(--fs-title); }
+.message-list { min-height: 300px; max-height: calc(100vh - 470px); padding: 28px; display: flex; flex-direction: column; gap: 20px; overflow-y: auto; }
 .message { max-width: 78%; }
-.message > span { display: block; margin-bottom: 6px; color: var(--ink-faint); font-size: 9px; font-weight: 800; letter-spacing: 0.08em; }
-.message p { margin: 0; padding: 13px 15px; white-space: pre-line; color: var(--ink); background: #f1efe9; border-radius: 4px 12px 12px 12px; font-size: 13px; }
+.message > span { display: block; margin-bottom: 7px; }
+.message p { margin: 0; padding: 14px 16px; white-space: pre-line; color: var(--ink-2); background: #f1efe9; border-radius: 4px 12px 12px 12px; font-size: var(--fs-body-sm); line-height: 1.6; }
 .message.user { align-self: flex-end; }
 .message.user > span { text-align: right; }
-.message.user p { color: var(--white); background: var(--navy); border-radius: 12px 4px 12px 12px; }
+.message.user p { color: var(--on-dark-title); background: var(--navy); border-radius: 12px 4px 12px 12px; }
 .composer { margin-top: auto; padding: 18px 20px; border-top: 1px solid var(--line); background: #faf9f5; }
 .composer textarea, .judgment textarea, .retry-form textarea {
   width: 100%;
@@ -225,119 +345,239 @@ p { color: var(--ink-soft); line-height: 1.65; }
   border: 1px solid #cbc8bf;
   border-radius: 8px;
   background: var(--white);
+  font-size: var(--fs-body-sm);
+  line-height: 1.55;
   outline: none;
 }
 .composer textarea { padding: 14px; }
 .composer textarea:focus, .judgment textarea:focus, .retry-form textarea:focus { border-color: var(--sage-strong); box-shadow: 0 0 0 3px rgba(46, 106, 79, 0.1); }
-.composer-actions { margin-top: 10px; display: flex; align-items: center; justify-content: space-between; }
-.training-progress { padding: 24px; }
-.coverage-number { margin: 26px 0 14px; display: flex; align-items: flex-end; justify-content: space-between; }
-.coverage-number strong { font-size: 34px; }
-.coverage-number span { padding-bottom: 5px; color: var(--ink-faint); font-size: 9px; }
+.composer-actions { margin-top: 12px; display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.training-progress { padding: 26px; }
+.coverage-number { margin: 28px 0 14px; display: flex; align-items: flex-end; justify-content: space-between; }
+.coverage-number strong { font-family: var(--font-mono); font-size: 2.375rem; font-weight: 600; color: var(--ink-3); line-height: 1; font-variant-numeric: tabular-nums; }
+.coverage-number span { padding-bottom: 6px; }
 .coverage-bar { height: 6px; overflow: hidden; background: #e3e1da; border-radius: 999px; }
 .coverage-bar i { display: block; height: 100%; background: var(--sage-strong); }
-.coverage-list { margin: 28px 0; display: grid; gap: 13px; }
-.coverage-list > div { display: flex; align-items: center; gap: 9px; font-size: 11px; }
-.training-progress > p { font-size: 10px; }
-.training-progress .button { width: 100%; margin-top: 16px; }
+.coverage-list { margin: 30px 0; display: grid; gap: 14px; }
+.coverage-list > div { display: flex; align-items: center; gap: 10px; font-size: var(--fs-body-sm); }
+.training-progress > p { font-size: var(--fs-aux); color: var(--ink-3); }
+.training-progress .button { width: 100%; margin-top: 18px; }
 
-.judgment { padding: clamp(28px, 4vw, 48px); }
-.judgment-grid { margin-top: 30px; display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
-.judgment-grid label { display: grid; gap: 7px; }
+/* ══════════════════════════ JUDGMENT CANVAS ════════════════════════════ */
+.judgment { padding: clamp(30px, 4vw, 50px); }
+.judgment-grid { margin-top: 32px; display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+.judgment-grid label { display: grid; gap: 8px; }
 .judgment-grid label.wide { grid-column: 1 / -1; }
-.judgment-grid label > span { font-size: 11px; font-weight: 750; }
+.judgment-grid label > span { font-size: var(--fs-aux); font-weight: 600; color: var(--ink); }
 .judgment textarea, .retry-form textarea { padding: 12px; }
-.judgment-actions { margin-top: 26px; padding-top: 22px; display: flex; align-items: center; justify-content: space-between; gap: 24px; border-top: 1px solid var(--line); }
-.judgment-actions p { margin: 0; font-size: 11px; }
+.judgment-actions { margin-top: 28px; padding-top: 24px; display: flex; align-items: center; justify-content: space-between; gap: 24px; border-top: 1px solid var(--line); }
+.judgment-actions p { margin: 0; font-size: var(--fs-body-sm); }
 
+/* ══════════════════════════ FEEDBACK ═══════════════════════════════════ */
 .feedback-layout { display: grid; gap: 18px; }
-.feedback-summary { padding: 34px; display: flex; align-items: center; justify-content: space-between; gap: 32px; }
-.feedback-summary h2 { max-width: 760px; font-size: 29px; }
-.feedback-summary p { margin-bottom: 0; }
+.feedback-summary { padding: 36px; display: flex; align-items: center; justify-content: space-between; gap: 36px; }
+.feedback-summary h2 { max-width: 760px; font-size: var(--fs-title-lg); line-height: 1.3; }
+.feedback-summary p { margin-bottom: 0; font-size: var(--fs-body-sm); }
 .score-orbit { flex: 0 0 128px; height: 128px; display: grid; place-content: center; text-align: center; border: 1px solid #3a4352; border-radius: 50%; }
-.score-orbit strong { display: block; font-size: 39px; line-height: 1; }
-.score-orbit span { color: #8f98a6; font-size: 10px; }
-.evidence-section, .retry-card { padding: 30px; }
-.evidence-list { margin-top: 26px; border-top: 1px solid var(--line); }
-.evidence-row { min-height: 112px; padding: 20px 0; display: grid; grid-template-columns: 190px 1fr 1fr; gap: 24px; border-bottom: 1px solid var(--line); }
-.evidence-row h3 { margin: 5px 0 0; font-size: 15px; }
-.evidence-level { color: var(--sage-strong); font-size: 9px; font-weight: 800; }
-.evidence-row blockquote { margin: 0; padding: 12px 14px; color: var(--ink); border-left: 2px solid var(--sage-strong); background: #f2f5f1; font-size: 11px; line-height: 1.6; }
-.evidence-row p { margin: 0; font-size: 11px; }
-.retry-card { display: grid; grid-template-columns: minmax(0, 1fr) 360px; gap: 36px; align-items: center; border-color: #edc0b9; }
-.retry-copy h2 { margin-bottom: 10px; font-size: 25px; }
-.evidence-quote { margin: 18px 0; padding: 14px; color: #74382f; border-left: 2px solid var(--coral); background: var(--coral-soft); font-size: 12px; }
-.retry-copy > strong { font-size: 12px; }
+.score-orbit strong { display: block; font-family: var(--font-mono); font-size: 2.5rem; font-weight: 600; line-height: 1; color: var(--on-dark-title); font-variant-numeric: tabular-nums; }
+.score-orbit span { color: var(--on-dark-aux); font-family: var(--font-mono); font-size: var(--fs-aux-sm); }
+.evidence-section, .retry-card { padding: 32px; }
+.evidence-list { margin-top: 28px; border-top: 1px solid var(--line); }
+.evidence-row { min-height: 112px; padding: 22px 0; display: grid; grid-template-columns: 200px 1fr 1fr; gap: 28px; border-bottom: 1px solid var(--line); }
+.evidence-row h3 { margin: 6px 0 0; font-size: var(--fs-title-sm); }
+.evidence-level { color: var(--sage-strong); font-family: var(--font-mono); font-size: var(--fs-aux-sm); font-weight: 600; letter-spacing: 0.04em; }
+/* The evidence itself — must be legible, it is the product */
+.evidence-row blockquote { margin: 0; padding: 14px 16px; color: var(--ink-2); border-left: 2px solid var(--sage-strong); background: #f2f5f1; font-size: var(--fs-body-sm); line-height: 1.65; }
+.evidence-row p { margin: 0; font-size: var(--fs-body-sm); }
+.retry-card { display: grid; grid-template-columns: minmax(0, 1fr) 360px; gap: 40px; align-items: center; border-color: #edc0b9; }
+.retry-copy h2 { margin-bottom: 12px; font-size: var(--fs-title-lg); }
+.retry-copy > p { font-size: var(--fs-body); }
+.evidence-quote { margin: 20px 0; padding: 15px; color: #74382f; border-left: 2px solid var(--coral); background: var(--coral-soft); font-size: var(--fs-body-sm); line-height: 1.6; }
+.retry-copy > strong { font-size: var(--fs-body-sm); font-weight: 600; color: var(--ink); }
 .retry-form { display: grid; gap: 12px; }
-.retry-form > span { color: var(--ink-soft); font-size: 11px; line-height: 1.55; }
-.retry-result { padding: 12px; color: #72352d; background: var(--coral-soft); border-radius: 8px; }
+.retry-form > span { color: var(--ink-2); font-size: var(--fs-body-sm); line-height: 1.55; }
+.retry-result { padding: 13px; color: #72352d; background: var(--coral-soft); border-radius: 8px; }
 .retry-result.success { color: #25583f; background: #e4efe7; }
-.retry-result p { margin: 5px 0 0; color: inherit; font-size: 10px; }
+.retry-result strong { font-size: var(--fs-body-sm); }
+.retry-result p { margin: 6px 0 0; color: inherit; font-size: var(--fs-aux); }
 .finish-row { display: flex; justify-content: flex-end; }
 
-.review-layout { display: grid; grid-template-columns: 280px minmax(0, 1fr); gap: 18px; }
+/* ══════════════════════════ REVIEW ═════════════════════════════════════ */
+.review-layout { display: grid; grid-template-columns: 288px minmax(0, 1fr); gap: 18px; }
 .review-list { padding: 18px; }
-.review-list > button { width: 100%; margin-top: 10px; padding: 14px; display: grid; gap: 5px; text-align: left; border: 1px solid transparent; border-radius: 8px; color: var(--ink); background: transparent; }
+.review-list > button { width: 100%; margin-top: 10px; padding: 15px; display: grid; gap: 6px; text-align: left; border: 1px solid transparent; border-radius: 8px; color: var(--ink); background: transparent; }
 .review-list > button:hover, .review-list > button.active { border-color: var(--line); background: #f1efe9; }
-.review-list button span { font-size: 12px; font-weight: 750; }
-.review-list button small { color: var(--ink-soft); line-height: 1.4; }
-.review-list button i { color: var(--sage-strong); font-size: 9px; font-style: normal; }
-.review-detail { padding: 30px; }
-.review-metrics { margin: 28px 0; display: grid; grid-template-columns: repeat(3, 1fr); border: 1px solid var(--line); border-radius: 9px; }
-.review-metrics > div { padding: 18px; border-right: 1px solid var(--line); }
+.review-list button span { font-size: var(--fs-body-sm); font-weight: 600; }
+.review-list button small { color: var(--ink-2); font-size: var(--fs-aux); line-height: 1.45; }
+.review-detail { padding: 32px; }
+.review-metrics { margin: 30px 0; display: grid; grid-template-columns: repeat(3, 1fr); border: 1px solid var(--line); border-radius: 9px; }
+.review-metrics > div { padding: 20px; border-right: 1px solid var(--line); }
 .review-metrics > div:last-child { border-right: 0; }
-.review-metrics span { display: block; color: var(--ink-faint); font-size: 9px; }
-.review-metrics strong { display: block; margin-top: 6px; font-size: 18px; }
+.review-metrics span { display: block; }
+.review-metrics strong { display: block; margin-top: 8px; font-family: var(--font-mono); font-size: var(--fs-title); font-weight: 600; color: var(--ink); font-variant-numeric: tabular-nums; }
 .review-evidence { display: grid; gap: 12px; }
-.review-evidence article { padding: 20px; border: 1px solid var(--line); border-radius: 9px; }
-.review-evidence article > span { color: var(--coral); font-size: 9px; font-weight: 800; }
-.review-evidence h3 { margin: 6px 0 12px; }
-.review-evidence blockquote { margin: 0 0 10px; color: var(--ink-soft); font-size: 12px; }
-.review-evidence p { margin-bottom: 0; font-size: 11px; }
-.retry-comparison { margin-top: 18px; padding: 18px; color: #70342c; background: var(--coral-soft); border-radius: 9px; }
+.review-evidence article { padding: 22px; border: 1px solid var(--line); border-radius: 9px; }
+.review-evidence article > span { color: var(--coral); font-family: var(--font-mono); font-size: var(--fs-aux-sm); font-weight: 600; letter-spacing: 0.04em; }
+.review-evidence h3 { margin: 8px 0 14px; font-size: var(--fs-title-sm); }
+.review-evidence blockquote { margin: 0 0 12px; color: var(--ink-2); font-size: var(--fs-body-sm); line-height: 1.6; }
+.review-evidence p { margin-bottom: 0; font-size: var(--fs-body-sm); }
+.retry-comparison { margin-top: 20px; padding: 20px; color: #70342c; background: var(--coral-soft); border-radius: 9px; }
 .retry-comparison.success { color: #285a42; background: #e4efe7; }
-.retry-comparison span { display: block; font-size: 9px; }
-.retry-comparison strong { display: block; margin: 7px 0; }
-.retry-comparison p { margin-bottom: 0; color: inherit; font-size: 11px; }
-.empty-state { min-height: 430px; padding: 50px; display: grid; place-content: center; justify-items: start; }
-.empty-number { color: var(--sage-strong); font-family: ui-monospace, monospace; }
-.empty-state h2 { margin: 24px 0 10px; font-size: 30px; }
-.empty-state p { max-width: 500px; }
-.empty-state .button { margin-top: 14px; }
+.retry-comparison span { display: block; font-family: var(--font-mono); font-size: var(--fs-aux-sm); letter-spacing: 0.03em; }
+.retry-comparison strong { display: block; margin: 8px 0; font-size: var(--fs-body); }
+.retry-comparison p { margin-bottom: 0; color: inherit; font-size: var(--fs-body-sm); }
+.empty-state { min-height: 430px; padding: 52px; display: grid; place-content: center; justify-items: start; }
+.empty-number { color: var(--sage-strong); font-family: var(--font-mono); font-size: var(--fs-aux); font-weight: 600; }
+.empty-state h2 { margin: 26px 0 12px; font-size: var(--fs-title-lg); }
+.empty-state p { max-width: 520px; font-size: var(--fs-body); }
+.empty-state .button { margin-top: 16px; }
 
+/* ══════════════════════════ ABILITY ════════════════════════════════════ */
 .ability-layout { display: grid; gap: 18px; }
-.ability-summary { padding: 34px; display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 40px; }
-.ability-summary h2 { max-width: 700px; font-size: 30px; }
-.ability-summary p { margin-bottom: 0; }
+.ability-summary { padding: 36px; display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 44px; }
+.ability-summary h2 { max-width: 720px; font-size: var(--fs-title-lg); line-height: 1.3; }
+.ability-summary p { margin-bottom: 0; font-size: var(--fs-body-sm); }
 .summary-stats { display: flex; align-items: center; }
-.summary-stats div { min-width: 105px; padding: 0 20px; border-left: 1px solid #394252; }
-.summary-stats strong { display: block; font-size: 28px; }
-.summary-stats span { color: #9da5b2; font-size: 9px; }
-.ability-table { padding: 30px; }
-.ability-table > article { min-height: 96px; display: grid; grid-template-columns: 44px minmax(0, 1fr) 180px 100px; align-items: center; gap: 16px; border-bottom: 1px solid var(--line); }
+.summary-stats div { min-width: 108px; padding: 0 22px; border-left: 1px solid #394252; }
+.summary-stats strong { display: block; font-family: var(--font-mono); font-size: 1.9rem; font-weight: 600; color: var(--on-dark-title); font-variant-numeric: tabular-nums; }
+.summary-stats span { color: var(--on-dark-aux); }
+.ability-table { padding: 32px; }
+.ability-table > article { min-height: 96px; display: grid; grid-template-columns: 46px minmax(0, 1fr) 190px 110px; align-items: center; gap: 18px; border-bottom: 1px solid var(--line); }
 .ability-table > article:last-child { border-bottom: 0; }
-.ability-table h3 { margin: 0 0 6px; font-size: 15px; }
-.ability-table p { margin: 0; font-size: 10px; }
-.ability-counts { display: flex; gap: 14px; color: var(--ink-faint); font-size: 9px; }
+.ability-table h3 { margin: 0 0 7px; font-size: var(--fs-title-sm); }
+.ability-table p { margin: 0; font-size: var(--fs-body-sm); }
+.ability-counts { display: flex; gap: 14px; }
 
+/* ══════════════════════════ LOGIN ══════════════════════════════════════ */
 .login-page { min-height: 100vh; display: grid; grid-template-columns: minmax(0, 1.1fr) minmax(420px, 0.9fr); background: var(--bg); }
-.login-story { padding: clamp(48px, 8vw, 110px); display: flex; flex-direction: column; justify-content: space-between; color: var(--white); background: var(--navy); }
+.login-story { padding: clamp(48px, 8vw, 110px); display: flex; flex-direction: column; justify-content: space-between; color: var(--on-dark-body); background: var(--navy); }
 .login-story .brand { width: fit-content; padding: 0; border: 0; }
-.login-story .brand span { color: #9da5b2; }
-.login-story h1 { max-width: 780px; margin: 70px 0 24px; font-size: clamp(44px, 6vw, 82px); line-height: 0.98; }
-.login-story > div > p { max-width: 650px; color: #bbc2cd; font-size: 16px; }
+.login-story .brand strong { color: var(--on-dark-title); }
+.login-story .brand span { color: var(--on-dark-aux); }
+/* The opening claim — biggest serif moment in the product */
+.login-story h1 { max-width: 780px; margin: 70px 0 26px; font-size: clamp(2.6rem, 1.7rem + 4vw, 4.9rem); font-weight: 600; line-height: 1.04; letter-spacing: -0.02em; color: var(--on-dark-title); }
+.login-story > div > p { max-width: 660px; color: var(--on-dark-body); font-size: var(--fs-lede); line-height: 1.7; }
 .login-proof { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
-.login-proof div { padding-top: 16px; border-top: 1px solid #374151; }
-.login-proof strong { display: block; font-size: 20px; }
-.login-proof span { color: #9da5b2; font-size: 10px; }
+.login-proof div { padding-top: 18px; border-top: 1px solid #374151; }
+.login-proof strong { display: block; font-family: var(--font-display); font-size: var(--fs-title); font-weight: 600; color: var(--on-dark-title); }
+.login-proof span { color: var(--on-dark-aux); }
 .login-entry { padding: clamp(48px, 7vw, 100px); display: grid; place-items: center; }
-.login-panel { width: min(430px, 100%); }
-.login-panel .mark { margin-bottom: 34px; }
-.login-panel h2 { font-size: 32px; }
-.login-panel > p { margin-bottom: 28px; }
+.login-panel { width: min(440px, 100%); }
+.login-panel .mark { margin-bottom: 36px; }
+.login-panel h2 { font-size: var(--fs-title-lg); }
+.login-panel > p { margin-bottom: 30px; font-size: var(--fs-body); }
 .login-panel .button { width: 100%; }
-.login-note { margin-top: 16px; color: var(--ink-faint); font-size: 10px; text-align: center; }
+.login-note { margin-top: 18px; color: var(--ink-3); font-family: var(--font-mono); font-size: var(--fs-aux-sm); text-align: center; }
+.login-form { display: grid; gap: 16px; }
+.login-form label { display: grid; gap: 8px; color: var(--ink-2); font-size: var(--fs-aux); font-weight: 600; }
+.login-form input { width: 100%; min-height: 48px; padding: 0 14px; border: 1px solid var(--line); border-radius: 10px; background: var(--white); color: var(--ink); font-size: var(--fs-body-sm); }
+.login-form input:focus { outline: 2px solid rgba(69, 111, 91, 0.24); outline-offset: 2px; border-color: var(--sage-strong); }
+.login-status { margin: 0; color: var(--ink-2); font-size: var(--fs-body-sm); }
 
+/* ══════════════════════════ RUNTIME & ERRORS ═══════════════════════════ */
+.runtime-notice { margin-bottom: 16px; padding: 13px 18px; display: flex; justify-content: space-between; gap: 18px; border: 1px solid var(--line); border-radius: 12px; background: rgba(255, 255, 255, 0.72); color: var(--ink-2); font-size: var(--fs-aux); }
+.runtime-notice strong { color: var(--coral); font-weight: 600; }
+.runtime-online { border-color: rgba(69, 111, 91, 0.24); background: rgba(226, 238, 230, 0.66); }
+.runtime-fallback { border-color: rgba(191, 112, 79, 0.28); background: rgba(250, 235, 226, 0.72); }
+.runtime-connecting { opacity: 0.78; }
+.error-page { min-height: 100vh; padding: 40px; display: grid; place-content: center; justify-items: start; background: var(--bg); }
+.error-page h1 { margin: 20px 0 12px; font-size: var(--fs-display); }
+.error-page p { max-width: 620px; font-size: var(--fs-lede); }
+.error-page .button { margin-top: 18px; }
+
+/* ══════════════════════════ WORLD WORKBENCH ════════════════════════════ */
+.world-workbench { display: flex; flex-direction: column; height: 100%; min-height: 0; }
+.wb-loading { padding: 40px; text-align: center; }
+.wb-header { display: flex; align-items: center; justify-content: space-between; padding: 18px 24px; border-bottom: 1px solid var(--line); gap: 16px; flex-shrink: 0; }
+.wb-header-left { display: flex; align-items: center; gap: 18px; }
+.wb-header-left h2 { margin: 0; font-size: var(--fs-title); }
+.wb-phase-tag { display: inline-flex; align-items: center; gap: 8px; padding: 5px 13px; border-radius: 99px; background: var(--sage); color: var(--sage-strong); font-family: var(--font-mono); font-size: var(--fs-aux-sm); font-weight: 600; letter-spacing: 0.03em; white-space: nowrap; }
+.wb-assisted-badge { padding: 3px 9px; border-radius: 99px; background: var(--coral-soft); color: var(--coral-strong); font-size: var(--fs-aux-sm); font-weight: 600; }
+.wb-error-banner { padding: 11px 24px; background: var(--coral-soft); color: var(--coral-strong); font-size: var(--fs-body-sm); border-bottom: 1px solid rgba(217, 92, 75, 0.2); }
+.wb-body { display: grid; grid-template-columns: minmax(0, 1.4fr) 368px; gap: 0; flex: 1; min-height: 0; overflow: hidden; }
+
+/* Timeline (left) */
+.wb-timeline { display: flex; flex-direction: column; border-right: 1px solid var(--line); overflow: hidden; }
+.wb-messages { flex: 1; overflow-y: auto; padding: 26px; display: flex; flex-direction: column; gap: 18px; }
+.wb-message { display: grid; gap: 6px; max-width: 680px; }
+.wb-message-world { justify-self: start; }
+.wb-message-user { justify-self: end; text-align: right; }
+.wb-message-role { text-transform: uppercase; letter-spacing: 0.08em; }
+.wb-message p { margin: 0; background: var(--surface-strong); color: var(--ink-2); padding: 13px 17px; border-radius: var(--radius-sm); font-size: var(--fs-body-sm); line-height: 1.6; white-space: pre-line; }
+.wb-message-user p { background: var(--navy); color: var(--on-dark-title); }
+.wb-composer { padding: 16px 24px; border-top: 1px solid var(--line); display: flex; flex-direction: column; gap: 12px; }
+.wb-composer textarea { width: 100%; padding: 13px; border: 1px solid var(--line); border-radius: var(--radius-sm); resize: vertical; background: var(--surface); color: var(--ink); font-size: var(--fs-body-sm); line-height: 1.55; }
+.wb-composer textarea:focus { outline: 2px solid var(--navy); outline-offset: 1px; }
+.wb-composer-actions { display: flex; align-items: center; gap: 12px; justify-content: flex-end; flex-wrap: wrap; }
+
+/* Panel (right) */
+.wb-panel { overflow-y: auto; padding: 22px; display: flex; flex-direction: column; gap: 18px; background: var(--bg); }
+.wb-facts { padding: 20px 22px; }
+.wb-facts ul { margin: 10px 0 0; padding-left: 20px; display: flex; flex-direction: column; gap: 8px; }
+.wb-facts li { font-size: var(--fs-body-sm); color: var(--ink-2); line-height: 1.55; }
+
+/* Decision form */
+.wb-decision-form { padding: 22px; }
+.wb-form-notice { font-size: var(--fs-body-sm); color: var(--coral-strong); margin: 8px 0 18px; line-height: 1.55; }
+.wb-field { display: flex; flex-direction: column; gap: 7px; margin-bottom: 16px; }
+.wb-field label { font-size: var(--fs-aux); font-weight: 600; color: var(--ink); }
+.wb-field textarea, .wb-field select { padding: 11px 13px; border: 1px solid var(--line); border-radius: var(--radius-sm); background: var(--surface); color: var(--ink); font-size: var(--fs-body-sm); line-height: 1.55; resize: vertical; }
+.wb-field textarea:focus, .wb-field select:focus { outline: 2px solid var(--navy); outline-offset: 1px; }
+.wb-evidence-checkboxes { display: flex; flex-direction: column; gap: 7px; }
+.wb-evidence-check { display: flex; align-items: center; gap: 9px; font-size: var(--fs-aux); font-family: var(--font-mono); color: var(--ink-3); cursor: pointer; }
+.wb-no-evidence { font-size: var(--fs-aux); color: var(--ink-3); }
+
+/* Reveal & Reflect */
+.wb-reveal, .wb-reflect { padding: 22px; }
+.wb-reveal p, .wb-reflect p { font-size: var(--fs-body-sm); line-height: 1.65; white-space: pre-line; }
+.wb-reveal .button, .wb-reflect .button { margin-top: 14px; }
+.wb-full-width { width: 100%; }
+.wb-reflect .wb-assisted-notice { margin-top: 14px; padding: 12px 15px; border-radius: var(--radius-sm); background: var(--coral-soft); color: var(--coral-strong); font-size: var(--fs-body-sm); line-height: 1.5; }
+
+/* ══════════════════════════ JUDGMENT PROFILE ═══════════════════════════ */
+.jp-loading, .jp-error { padding: 40px; text-align: center; }
+.jp-empty { padding: 44px; display: flex; flex-direction: column; gap: 18px; }
+.jp-empty h2 { font-size: var(--fs-title-lg); }
+.jp-empty > p { max-width: 560px; font-size: var(--fs-body); }
+.jp-empty-facts { margin: 0; padding-left: 22px; display: flex; flex-direction: column; gap: 10px; color: var(--ink-2); font-size: var(--fs-body-sm); line-height: 1.6; }
+.jp-layout { display: flex; flex-direction: column; gap: 26px; padding: 26px; }
+.jp-summary { padding: 32px 36px; display: grid; grid-template-columns: 1fr auto; gap: 32px; align-items: start; border-radius: var(--radius); }
+.jp-summary h2 { font-size: var(--fs-title-lg); line-height: 1.3; }
+.jp-summary p { font-size: var(--fs-body-sm); }
+.jp-summary-stats { display: flex; gap: 32px; flex-shrink: 0; }
+.jp-summary-stats > div { text-align: center; }
+.jp-summary-stats strong { display: block; font-family: var(--font-mono); font-size: 1.9rem; font-weight: 600; letter-spacing: -0.02em; color: var(--on-dark-title); font-variant-numeric: tabular-nums; }
+.jp-summary-stats span { font-size: var(--fs-aux-sm); color: var(--on-dark-aux); }
+.jp-hypothesis-list { display: flex; flex-direction: column; gap: 18px; }
+.jp-hypothesis { padding: 24px 28px; border-radius: var(--radius); }
+.jp-hypothesis-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; margin-bottom: 12px; }
+/* Hypothesis name — a claim, so serif and present */
+.jp-hypothesis-meta h3 { margin: 0 0 8px; font-size: var(--fs-title); }
+.jp-confidence { display: inline-block; padding: 4px 11px; border-radius: 99px; font-family: var(--font-mono); font-size: var(--fs-aux-sm); font-weight: 600; letter-spacing: 0.02em; background: var(--sage); color: var(--sage-strong); }
+.jp-expand-btn { font-size: var(--fs-body-sm); white-space: nowrap; color: var(--ink-2); }
+.jp-triggers { margin-bottom: 14px; }
+.jp-trigger-list { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 8px; }
+.jp-trigger-tag { padding: 4px 11px; border-radius: 99px; background: var(--surface-strong); color: var(--ink-2); font-size: var(--fs-aux); }
+.jp-no-evidence { font-size: var(--fs-body-sm); color: var(--ink-3); margin: 10px 0 0; }
+.jp-evidence-groups { display: flex; flex-direction: column; gap: 22px; margin-top: 18px; }
+.jp-evidence-groups section { display: flex; flex-direction: column; gap: 9px; }
+
+/* Evidence card — provenance-forward: the record is the point */
+.ev-card { padding: 14px 18px; border: 1px solid var(--line); border-radius: var(--radius-sm); background: var(--bg); display: flex; flex-direction: column; gap: 8px; }
+.ev-card-header { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
+.ev-badge { padding: 3px 9px; border-radius: 99px; font-family: var(--font-mono); font-size: var(--fs-aux-sm); font-weight: 600; letter-spacing: 0.02em; }
+.ev-badge-supporting { background: var(--sage); color: var(--sage-strong); }
+.ev-badge-counter    { background: var(--coral-soft); color: var(--coral-strong); }
+.ev-badge-assisted   { background: var(--surface-strong); color: var(--ink-2); }
+.ev-badge-transfer   { background: var(--indigo-soft); color: var(--indigo); }
+.ev-tag { padding: 3px 9px; border-radius: 4px; font-family: var(--font-mono); font-size: var(--fs-aux-sm); font-weight: 500; }
+.ev-tag-transfer   { background: var(--indigo-soft); color: var(--indigo); }
+.ev-tag-correction { background: var(--amber-soft); color: var(--amber); }
+.ev-card-meta { display: flex; gap: 14px; }
+.ev-card-link { display: flex; align-items: center; gap: 9px; }
+.ev-dec-id { font-family: var(--font-mono); font-size: var(--fs-aux-sm); color: var(--ink-3); background: var(--surface-strong); padding: 3px 7px; border-radius: 4px; word-break: break-all; }
+
+/* ══════════════════════════ RESPONSIVE ═════════════════════════════════ */
 @media (max-width: 1180px) {
   .today-layout { grid-template-columns: 1fr; }
   .hero-training { grid-template-columns: 1fr; }
@@ -355,10 +595,10 @@ p { color: var(--ink-soft); line-height: 1.65; }
   .brand { padding-bottom: 14px; }
   .sidebar nav { grid-template-columns: repeat(2, 1fr); margin-top: 14px; }
   .sidebar-footer { display: none; }
-  .topbar { min-height: auto; padding: 22px 20px; }
+  .topbar { min-height: auto; padding: 24px 20px; }
   .user { display: none; }
   .content { padding: 20px; }
-  .hero-training, .focus-card, .map-preview, .weekly { padding: 24px; }
+  .hero-training, .focus-card, .map-preview, .weekly { padding: 26px; }
   .focus-grid, .map-intro, .review-layout, .ability-summary, .retry-card { grid-template-columns: 1fr; }
   .scenario-grid { grid-template-columns: 1fr; }
   .training-shell { grid-template-columns: 1fr; }
@@ -368,313 +608,23 @@ p { color: var(--ink-soft); line-height: 1.65; }
   .judgment-grid label.wide { grid-column: 1; }
   .judgment-actions, .feedback-summary { align-items: flex-start; flex-direction: column; }
   .evidence-row { grid-template-columns: 1fr; }
-  .ability-table > article { grid-template-columns: 36px minmax(0, 1fr); padding: 18px 0; }
+  .ability-table > article { grid-template-columns: 38px minmax(0, 1fr); padding: 20px 0; }
   .ability-counts, .ability-table .mastery { grid-column: 2; }
   .login-page { grid-template-columns: 1fr; }
   .login-story { min-height: 560px; }
+  .runtime-notice { align-items: flex-start; flex-direction: column; gap: 6px; }
+  /* World workbench */
+  .wb-body { grid-template-columns: 1fr; grid-template-rows: 1fr auto; }
+  .wb-panel { border-top: 1px solid var(--line); max-height: 50vh; }
+  .wb-header { flex-wrap: wrap; }
+  /* Judgment profile */
+  .jp-summary { grid-template-columns: 1fr; }
+  .jp-summary-stats { justify-content: flex-start; }
+  .jp-layout { padding: 18px; }
 }
 
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { scroll-behavior: auto !important; transition: none !important; }
-}
-
-.runtime-notice { margin-bottom: 14px; padding: 12px 16px; display: flex; justify-content: space-between; gap: 18px; border: 1px solid var(--line); border-radius: 12px; background: rgba(255, 255, 255, 0.72); color: var(--ink-muted); font-size: 10px; }
-.runtime-notice strong { color: var(--coral); font-weight: 600; }
-.runtime-online { border-color: rgba(69, 111, 91, 0.24); background: rgba(226, 238, 230, 0.66); }
-.runtime-fallback { border-color: rgba(191, 112, 79, 0.28); background: rgba(250, 235, 226, 0.72); }
-.runtime-connecting { opacity: 0.78; }
-.login-form { display: grid; gap: 14px; }
-.login-form label { display: grid; gap: 8px; color: var(--ink-muted); font-size: 10px; }
-.login-form input { width: 100%; min-height: 48px; padding: 0 14px; border: 1px solid var(--line); border-radius: 10px; background: var(--white); color: var(--ink); font: inherit; }
-.login-form input:focus { outline: 2px solid rgba(69, 111, 91, 0.24); outline-offset: 2px; border-color: var(--sage-strong); }
-.login-status { margin: 0; color: var(--ink-muted); font-size: 10px; }
-
-@media (max-width: 820px) {
-  .runtime-notice { align-items: flex-start; flex-direction: column; gap: 5px; }
-}
-
-.error-page { min-height: 100vh; padding: 40px; display: grid; place-content: center; justify-items: start; background: var(--bg); }
-.error-page h1 { margin: 18px 0 10px; font-size: clamp(32px, 5vw, 56px); }
-.error-page p { max-width: 620px; }
-.error-page .button { margin-top: 16px; }
-
-/* ── World Workbench ───────────────────────────────────────────── */
-.world-workbench { display: flex; flex-direction: column; height: 100%; min-height: 0; }
-
-.wb-loading { padding: 40px; text-align: center; }
-
-.wb-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 16px 24px;
-  border-bottom: 1px solid var(--line);
-  gap: 16px;
-  flex-shrink: 0;
-}
-.wb-header-left { display: flex; align-items: center; gap: 16px; }
-.wb-header-left h2 { margin: 0; font-size: 18px; }
-
-.wb-phase-tag {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 4px 12px;
-  border-radius: 99px;
-  background: var(--sage);
-  color: var(--sage-strong);
-  font-size: 12px;
-  font-weight: 650;
-  white-space: nowrap;
-}
-.wb-assisted-badge {
-  padding: 2px 8px;
-  border-radius: 99px;
-  background: var(--coral-soft);
-  color: var(--coral);
-  font-size: 11px;
-  font-weight: 700;
-}
-
-.wb-error-banner {
-  padding: 10px 24px;
-  background: var(--coral-soft);
-  color: var(--coral);
-  font-size: 13px;
-  border-bottom: 1px solid rgba(230, 107, 91, 0.2);
-}
-
-.wb-body {
-  display: grid;
-  grid-template-columns: minmax(0, 1.4fr) 360px;
-  gap: 0;
-  flex: 1;
-  min-height: 0;
-  overflow: hidden;
-}
-
-/* Timeline (left) */
-.wb-timeline {
-  display: flex;
-  flex-direction: column;
-  border-right: 1px solid var(--line);
-  overflow: hidden;
-}
-.wb-messages {
-  flex: 1;
-  overflow-y: auto;
-  padding: 24px;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-.wb-message { display: grid; gap: 4px; max-width: 680px; }
-.wb-message-world { justify-self: start; }
-.wb-message-user { justify-self: end; text-align: right; }
-.wb-message-role { font-size: 10px; font-weight: 700; color: var(--ink-faint); text-transform: uppercase; letter-spacing: 0.06em; }
-.wb-message p { margin: 0; background: var(--surface-strong); padding: 12px 16px; border-radius: var(--radius-sm); white-space: pre-line; }
-.wb-message-user p { background: var(--navy); color: var(--white); }
-
-.wb-composer {
-  padding: 16px 24px;
-  border-top: 1px solid var(--line);
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-.wb-composer textarea {
-  width: 100%;
-  padding: 12px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  resize: vertical;
-  background: var(--surface);
-}
-.wb-composer textarea:focus { outline: 2px solid var(--navy); outline-offset: 1px; }
-.wb-composer-actions { display: flex; align-items: center; gap: 10px; justify-content: flex-end; }
-
-/* Panel (right) */
-.wb-panel {
-  overflow-y: auto;
-  padding: 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  background: var(--bg);
-}
-
-.wb-facts { padding: 16px 20px; }
-.wb-facts ul { margin: 8px 0 0; padding-left: 18px; display: flex; flex-direction: column; gap: 6px; }
-.wb-facts li { font-size: 13px; color: var(--ink-soft); line-height: 1.5; }
-
-/* Decision form */
-.wb-decision-form { padding: 20px; }
-.wb-form-notice { font-size: 12px; color: var(--coral); margin: 6px 0 16px; }
-.wb-field { display: flex; flex-direction: column; gap: 6px; margin-bottom: 14px; }
-.wb-field label { font-size: 12px; font-weight: 650; color: var(--ink); }
-.wb-field textarea, .wb-field select {
-  padding: 10px 12px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  background: var(--surface);
-  resize: vertical;
-}
-.wb-field textarea:focus, .wb-field select:focus { outline: 2px solid var(--navy); outline-offset: 1px; }
-.wb-evidence-checkboxes { display: flex; flex-direction: column; gap: 6px; }
-.wb-evidence-check { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--ink-soft); cursor: pointer; }
-.wb-no-evidence { font-size: 12px; color: var(--ink-faint); }
-
-/* Reveal & Reflect */
-.wb-reveal, .wb-reflect { padding: 20px; }
-.wb-reflect .wb-assisted-notice {
-  margin-top: 12px;
-  padding: 10px 14px;
-  border-radius: var(--radius-sm);
-  background: var(--coral-soft);
-  color: var(--coral);
-  font-size: 12px;
-}
-
-/* Mobile */
-@media (max-width: 820px) {
-  .wb-body { grid-template-columns: 1fr; grid-template-rows: 1fr auto; }
-  .wb-panel { border-top: 1px solid var(--line); max-height: 50vh; }
-  .wb-header { flex-wrap: wrap; }
-}
-
-/* ── Judgment Profile Panel ────────────────────────────────────── */
-.jp-loading, .jp-error { padding: 40px; text-align: center; }
-
-.jp-empty {
-  padding: 40px;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-.jp-empty-facts {
-  margin: 0;
-  padding-left: 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  color: var(--ink-soft);
-  font-size: 14px;
-  line-height: 1.6;
-}
-
-.jp-layout { display: flex; flex-direction: column; gap: 24px; padding: 24px; }
-
-.jp-summary {
-  padding: 28px 32px;
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 24px;
-  align-items: start;
-  border-radius: var(--radius);
-}
-.jp-summary-stats {
-  display: flex;
-  gap: 28px;
-  flex-shrink: 0;
-}
-.jp-summary-stats > div { text-align: center; }
-.jp-summary-stats strong { display: block; font-size: 28px; letter-spacing: -0.04em; color: var(--white); }
-.jp-summary-stats span { font-size: 11px; color: rgba(255,255,255,0.6); }
-
-.jp-hypothesis-list { display: flex; flex-direction: column; gap: 16px; }
-
-.jp-hypothesis {
-  padding: 20px 24px;
-  border-radius: var(--radius);
-}
-.jp-hypothesis-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 10px;
-}
-.jp-hypothesis-meta h3 { margin: 0 0 6px; font-size: 16px; }
-.jp-confidence {
-  display: inline-block;
-  padding: 3px 10px;
-  border-radius: 99px;
-  font-size: 12px;
-  font-weight: 650;
-  background: var(--sage);
-  color: var(--sage-strong);
-}
-.jp-expand-btn { font-size: 13px; white-space: nowrap; color: var(--ink-soft); }
-
-.jp-triggers { margin-bottom: 12px; }
-.jp-trigger-list { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
-.jp-trigger-tag {
-  padding: 3px 10px;
-  border-radius: 99px;
-  background: var(--surface-strong);
-  color: var(--ink-soft);
-  font-size: 12px;
-}
-
-.jp-no-evidence { font-size: 13px; color: var(--ink-faint); margin: 8px 0 0; }
-
-.jp-evidence-groups { display: flex; flex-direction: column; gap: 20px; margin-top: 16px; }
-.jp-evidence-groups section { display: flex; flex-direction: column; gap: 8px; }
-
-/* Evidence card */
-.ev-card {
-  padding: 12px 16px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  background: var(--bg);
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-.ev-card-header { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-.ev-badge {
-  padding: 2px 8px;
-  border-radius: 99px;
-  font-size: 11px;
-  font-weight: 700;
-}
-.ev-badge-supporting { background: var(--sage); color: var(--sage-strong); }
-.ev-badge-counter    { background: var(--coral-soft); color: var(--coral); }
-.ev-badge-assisted   { background: var(--surface-strong); color: var(--ink-soft); }
-.ev-badge-transfer   { background: #e8eaf6; color: #3949ab; }
-
-.ev-tag {
-  padding: 2px 8px;
-  border-radius: 4px;
-  font-size: 11px;
-  font-weight: 600;
-}
-.ev-tag-transfer   { background: #e8eaf6; color: #3949ab; }
-.ev-tag-correction { background: #fff3e0; color: #e65100; }
-
-.ev-card-meta {
-  display: flex;
-  gap: 12px;
-  font-size: 11px;
-  color: var(--ink-faint);
-}
-.ev-card-link { display: flex; align-items: center; gap: 8px; }
-.ev-dec-id {
-  font-family: "Cascadia Code", "Fira Code", monospace;
-  font-size: 11px;
-  color: var(--ink-soft);
-  background: var(--surface-strong);
-  padding: 2px 6px;
-  border-radius: 4px;
-  word-break: break-all;
-}
-
-.jp-updated { margin-top: 12px; font-size: 11px; color: var(--ink-faint); }
-
-@media (max-width: 820px) {
-  .jp-summary { grid-template-columns: 1fr; }
-  .jp-summary-stats { justify-content: flex-start; }
-  .jp-layout { padding: 16px; }
 }
 
 .v2-shell {

--- a/product-drill-app/src/app/world-workbench.tsx
+++ b/product-drill-app/src/app/world-workbench.tsx
@@ -720,10 +720,9 @@ export function WorldWorkbench({ initialWorldId, onClose, onRunComplete }: Workb
           {/* commit 阶段：揭示后果按钮 */}
           {canRevealConsequences(state) && (
             <button
-              className="button button-coral"
+              className="button button-coral wb-full-width"
               disabled={busy}
               onClick={() => { void handleReveal(); }}
-              style={{ width: "100%", marginTop: 12 }}
               type="button"
             >
               {busy ? "揭示中…" : "揭示后果"}
@@ -734,12 +733,11 @@ export function WorldWorkbench({ initialWorldId, onClose, onRunComplete }: Workb
           {state.phase === "reveal" && (
             <div className="wb-reveal surface">
               <span className="section-kicker">后果回放</span>
-              <p style={{ whiteSpace: "pre-line" }}>{revealContent}</p>
+              <p>{revealContent}</p>
               <button
                 className="button button-secondary"
                 disabled={busy}
                 onClick={() => { void handleAdvanceToReflect(); }}
-                style={{ marginTop: 12 }}
                 type="button"
               >
                 {busy ? "生成反馈…" : "查看证据反馈"}
@@ -751,7 +749,7 @@ export function WorldWorkbench({ initialWorldId, onClose, onRunComplete }: Workb
           {state.phase === "reflect" && (
             <div className="wb-reflect surface">
               <span className="section-kicker">证据反馈</span>
-              <p style={{ whiteSpace: "pre-line" }}>{reflectContent}</p>
+              <p>{reflectContent}</p>
               {state.was_assisted && (
                 <p className="wb-assisted-notice">
                   ⚠ 本轮使用了提示，决策证据标记为辅助，不计入独立能力趋势。
@@ -760,7 +758,6 @@ export function WorldWorkbench({ initialWorldId, onClose, onRunComplete }: Workb
               <button
                 className="button button-primary"
                 onClick={handleFinish}
-                style={{ marginTop: 16 }}
                 type="button"
               >
                 完成本轮训练

--- a/product-drill-app/tests/information-hierarchy.spec.ts
+++ b/product-drill-app/tests/information-hierarchy.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+import { enterApp } from "./e2e-helpers";
+
+test("separates claims, evidence, and provenance visually", async ({ page }) => {
+  await enterApp(page);
+
+  const styles = await page.evaluate(() => {
+    const read = (selector: string) => {
+      const element = document.querySelector(selector);
+      if (!element) throw new Error(`Missing hierarchy element: ${selector}`);
+      const style = getComputedStyle(element);
+      return { color: style.color, fontFamily: style.fontFamily };
+    };
+
+    return {
+      claim: read(".topbar h1"),
+      evidence: read(".topbar p"),
+      provenance: read(".sidebar-footer > span")
+    };
+  });
+
+  expect(styles.claim).toEqual({
+    color: "rgb(21, 26, 34)",
+    fontFamily: '"Noto Serif SC", "Source Han Serif SC", "Songti SC", STSongti, STSong, SimSun, NSimSun, serif'
+  });
+  expect(styles.evidence).toEqual({
+    color: "rgb(65, 74, 88)",
+    fontFamily: 'Inter, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC", system-ui, -apple-system, "Segoe UI", sans-serif'
+  });
+  expect(styles.provenance).toEqual({
+    color: "rgb(123, 130, 144)",
+    fontFamily: '"IBM Plex Mono", "JetBrains Mono", "Cascadia Code", "SF Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace'
+  });
+});


### PR DESCRIPTION
## What changed

- establish Claim / Evidence / Provenance typography and ink tiers in the production UI
- replace workbench inline presentation styles with shared CSS classes
- add a Chromium computed-style test for the three information tiers

## Why

The frontend previously lacked a consistent visual distinction between product claims, supporting evidence, and provenance metadata. This makes decision evidence easier to scan while preserving traceability.

## Impact

Users get clearer hierarchy across the existing screens. The change uses local font stacks only; no Google Fonts/CDN dependency is introduced. The `--ink-muted` compatibility alias remains intact.

## Validation

- build passed
- typecheck passed
- 238 tests passed
- golden eval passed
- Chromium E2E 20/20 passed
- desktop and 390x844 production-browser checks passed
- `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities
- independent standards/spec review completed; no blocking findings
- Codex Security diff scan `717d3944-2ceb-449c-8828-126a7d5fbd71`: 0 findings, complete coverage