### PR TITLE
fix: stabilize mobile responsive navigation

### DIFF
--- a/product-drill-app/src/app/app-shell.tsx
+++ b/product-drill-app/src/app/app-shell.tsx
@@ -1,6 +1,6 @@
 ﻿"use client";
 
-import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import { WorldWorkbench } from "./world-workbench";
 import { JudgmentProfilePanel } from "./judgment-profile-panel";
 import { ANALYTICS_EVENTS } from "../lib/analytics/events";
@@ -837,6 +837,7 @@ export function AppShell({
   const [historyRecords, setHistoryRecords] = useState<TrainingHistoryRecord[]>([]);
   const [storageReady, setStorageReady] = useState(false);
   const [historyStatus, setHistoryStatus] = useState<"loading" | "server" | "local">("loading");
+  const topbarRef = useRef<HTMLElement>(null);
   const meta = getViewMeta(view);
   const storageKey = `${STORAGE_KEY}:${userId}`;
 
@@ -878,6 +879,12 @@ export function AppShell({
     if (!storageReady) return;
     window.localStorage.setItem(storageKey, JSON.stringify({ version: 1, records: historyRecords }));
   }, [historyRecords, storageKey, storageReady]);
+
+  useEffect(() => {
+    topbarRef.current?.focus({ preventScroll: true });
+    const timer = window.setTimeout(() => window.scrollTo(0, 0), 100);
+    return () => window.clearTimeout(timer);
+  }, [activeTraining, activeWorkbenchWorldId, view]);
 
   function startTraining(scenarioId: string, mode: TrainingSession["mode"] = "练习") {
     setActiveTraining({ scenarioId, mode });
@@ -948,7 +955,7 @@ export function AppShell({
       </aside>
 
       <section className="main">
-        <header className="topbar">
+        <header className="topbar" ref={topbarRef} tabIndex={-1}>
           <div>
             <h1>{pageTitle}</h1>
             <p>{pageDescription}</p>

--- a/product-drill-app/src/app/globals.css
+++ b/product-drill-app/src/app/globals.css
@@ -433,7 +433,7 @@ p { color: var(--ink-2); line-height: 1.66; }
 .empty-state .button { margin-top: 16px; }
 
 /* ══════════════════════════ ABILITY ════════════════════════════════════ */
-.ability-layout { display: grid; gap: 18px; }
+.ability-layout { display: grid; grid-template-columns: minmax(0, 1fr); gap: 18px; }
 .ability-summary { padding: 36px; display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 44px; }
 .ability-summary h2 { max-width: 720px; font-size: var(--fs-title-lg); line-height: 1.3; }
 .ability-summary p { margin-bottom: 0; font-size: var(--fs-body-sm); }
@@ -610,6 +610,7 @@ p { color: var(--ink-2); line-height: 1.66; }
   .evidence-row { grid-template-columns: 1fr; }
   .ability-table > article { grid-template-columns: 38px minmax(0, 1fr); padding: 20px 0; }
   .ability-counts, .ability-table .mastery { grid-column: 2; }
+  .summary-stats div { min-width: 0; }
   .login-page { grid-template-columns: 1fr; }
   .login-story { min-height: 560px; }
   .runtime-notice { align-items: flex-start; flex-direction: column; gap: 6px; }

--- a/product-drill-app/tests/app-shell.spec.ts
+++ b/product-drill-app/tests/app-shell.spec.ts
@@ -14,3 +14,28 @@ test("navigates between the four direction A modules", async ({ page }) => {
     await expect(page.getByRole("heading", { level: 1, name: heading })).toBeVisible();
   }
 });
+
+test("keeps the ability view within the mobile viewport", async ({ page }) => {
+  await enterApp(page);
+  await page.setViewportSize({ width: 375, height: 844 });
+  await page.getByRole("button", { name: "04 我的能力 查看掌握状态和证据", exact: true }).click();
+
+  const widths = await page.evaluate(() => ({
+    client: document.documentElement.clientWidth,
+    scroll: document.documentElement.scrollWidth
+  }));
+
+  expect(widths.scroll).toBe(widths.client);
+});
+
+test("keeps the world workbench heading in the mobile viewport", async ({ page }) => {
+  await enterApp(page);
+  await page.setViewportSize({ width: 375, height: 600 });
+  await page.evaluate(() => {
+    document.body.style.minHeight = "2000px";
+    window.scrollTo(0, 500);
+  });
+  await page.getByRole("button", { name: "进入世界工作台", exact: true }).click();
+
+  await expect(page.getByRole("heading", { level: 1, name: "世界工作台" })).toBeInViewport();
+});


### PR DESCRIPTION
## What changed

- constrain the ability layout and mobile summary cells so 375–390px viewports do not overflow horizontally
- focus the app topbar and restore scroll position after view/workbench transitions so the world-workbench heading remains visible
- add Playwright regressions for both mobile behaviors

## Why

The ability grid inherited intrinsic minimum widths from nested content, leaving horizontal overflow on narrow screens. View changes also preserved the prior page scroll offset, so entering the world workbench could place its heading above the viewport.

## User impact

Mobile learners can use the ability page without sideways scrolling and always see the destination heading after navigating into the world workbench.

## Validation

- `npm run typecheck`
- `npm test` — 238/238
- `npm run eval:golden` — 30 fixtures validated, 31/31 tests
- `npm run e2e` — production build + Chromium 22/22
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- Browser QA at 1440×900 and 390×844: no horizontal overflow, heading/focus behavior verified, console clean
- `git diff --check`

## Review gates

- independent spec review: 0 findings
- Codex Security diff scan `e1f8a2eb-7794-4f37-98db-c025bdc4bf0e`: 0 findings, 2/2 source rows closed, complete coverage
